### PR TITLE
Update composer.json for Laravel 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
     "name": "rokde/laravel-bootstrap-formbuilder",
     "description": "Laravel 5 FormBuilder for Blade Engine and the Twitter Bootstrap CSS Framework",
     "require": {
-        "laravelcollective/html": "~5.1",
-        "illuminate/support": "5.1.*"
+        "laravelcollective/html": "^5.1",
+        "illuminate/support": "^5.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The `5.1.*` version constraint locks the library to Laravel 5.1 - changing it to `^5.1` allows SemVer to take hold, permitting Laravel 5.2 (but unlike `>=5.1`, not 6.x).  This PR makes that change.
