### PR TITLE
Switch from old to current method

### DIFF
--- a/src/HtmlServiceProvider.php
+++ b/src/HtmlServiceProvider.php
@@ -41,7 +41,7 @@ class HtmlServiceProvider extends ServiceProvider
      */
     protected function registerHtmlBuilder()
     {
-        $this->app->bindShared('html', function ($app) {
+        $this->app->singleton('html', function ($app) {
             return new HtmlBuilder($app['url']);
         });
     }
@@ -53,7 +53,7 @@ class HtmlServiceProvider extends ServiceProvider
      */
     protected function registerFormBuilder()
     {
-        $this->app->bindShared('form', function ($app) {
+        $this->app->singleton('form', function ($app) {
             $form = new BootstrapFormBuilder($app['html'], $app['url'], $app['session.store']->getToken());
 
             return $form->setSessionStore($app['session.store']);


### PR DESCRIPTION
`$this->app->bindShared()` was deprecated in Laravel 5.1, and removed in 5.2.  It has been replaced by the (identical in all but name) `->singleton()` method.  This PR addresses this change.
