### PR TITLE
Probably don't intend to register anything in the App namespace

### DIFF
--- a/src/HtmlServiceProvider.php
+++ b/src/HtmlServiceProvider.php
@@ -31,7 +31,7 @@ class HtmlServiceProvider extends ServiceProvider
         $this->registerFormBuilder();
 
         $this->app->alias('html', 'Collective\Html\HtmlBuilder');
-        $this->app->alias('form', 'App\Html\BootstrapFormBuilder');
+        $this->app->alias('form', 'Rokde\LaravelBootstrap\Html\BootstrapFormBuilder');
     }
 
     /**
@@ -67,6 +67,6 @@ class HtmlServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return ['html', 'form', 'Collective\Html\HtmlBuilder', 'App\Html\BootstrapFormBuilder'];
+        return ['html', 'form', 'Collective\Html\HtmlBuilder', 'Rokde\LaravelBootstrap\Html\BootstrapFormBuilder'];
     }
 }


### PR DESCRIPTION
Fixed the namespacing so that the service container references the `Rokde\LaravelBootstrap\` namespace instead of the `App\` namespace.  The singleton is actually correct, but the alias was not.
